### PR TITLE
Design fixes for the course template

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,7 +46,7 @@
 
 			<p align="right">
 				<br>
-				<a href="http://cityandguilds.com">
+				<a href="http://cityandguilds.com" class="no-underline">
 					<img src="{{site.baseurl}}/img/CG-logo.png" alt="City &amp; Guilds">
 				</a>
 			</p>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -13,7 +13,7 @@
 	<div class="container">
 		<div class="collapse navbar-collapse" id="p2pu-menu">
 			<ul class="p2pu-logo">
-				<li><a class="p2pu-tab" href="#"><img src="{{ site.baseurl }}/img/OB101-logo.png" alt="{{ site.title }}" /></a></li>
+				<li><a class="p2pu-tab" href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/img/OB101-logo.png" alt="{{ site.title }}" /></a></li>
 			</ul>
 			<ul class="nav navbar-nav">
 				<li>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -50,8 +50,7 @@
 </script>
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-<script type="text/javascript"
-        src="//s3.amazonaws.com/p2pu-navigation-widget/p2pu_menu_slider.js"></script>
+
 <script src="{{site.baseurl}}/js/init.js"></script>
 <script src="{{site.baseurl}}/js/gh_link_helper.js"></script>
 

--- a/_sass/_common.scss
+++ b/_sass/_common.scss
@@ -17,6 +17,10 @@ body {
 
 .p2pu-footer {
 	margin-top: 0;
+
+	.no-underline{
+		border-bottom: 0;
+	}
 }
 
 .sidebar {


### PR DESCRIPTION
Hi guys,

I am sending two fixes for the template that I thought you might appreciate. 
- One is the P2PU slider that is commitng from the top whenever #OB101 logo is clicked. It is loaded dynamicaly so it is not really possible to delete it from HTML as it is not there
  ![thinkoutloudissues1](https://cloud.githubusercontent.com/assets/2290441/9170058/d761ee52-3f5f-11e5-977a-db5c9932658a.png)
  - I am thinking that this is probably something you do not need, since it is all sorts of links back to the P2PU webpage
  - removing that also removes the colorful stripe at the top of the page, if you would still wish to have that let me know and I can add it
- The other issue that I notice was the weird underline for the logo in the footer which I fixed by adding a class that would remove the underline and also serve as a future item which would act same as link but have no underline

![thinkoutloudissues2](https://cloud.githubusercontent.com/assets/2290441/9170068/eab610a0-3f5f-11e5-95e1-471d53464edf.png)

Hope this helps a little.
Erika
